### PR TITLE
Update remarkMath plugin configuration in MarkdownText component

### DIFF
--- a/src/components/thread/markdown-text.tsx
+++ b/src/components/thread/markdown-text.tsx
@@ -300,7 +300,7 @@ const MarkdownTextImpl: FC<{ children: string }> = ({ children }) => {
   return (
     <div className="markdown-content">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
         rehypePlugins={[rehypeRaw, rehypeKatex]}
         components={defaultComponents}
       >


### PR DESCRIPTION
- Modified the `remarkMath` plugin to disable single dollar text math rendering for improved compatibility with markdown content.